### PR TITLE
Fixed SLPF rule target reference

### DIFF
--- a/assets/js/myscript.js
+++ b/assets/js/myscript.js
@@ -333,6 +333,13 @@ function targetFunction(selectedValue) {
 	definitions = openc2CommandSchema.definitions;
 	$('#targetButtonId').text(selectedValue);
 	openc2command['target'] = {};
+
+	if (selectedValue === 'command') {
+		selectedValue = 'command_id';
+	} else if (selectedValue === 'slpf:rule_number') {
+		selectedValue = 'slpf_rule_id';
+	}
+	
 	if (definitions[selectedValue].type == 'string') {
 		openc2command['target'][selectedValue] = "";
 	} else if (definitions[selectedValue].type == 'object') {


### PR DESCRIPTION
**Problem**: If you select the "slpf:rule_number" as the target, the reference cannot be found in the definitions section of the command.json file. This results in an error in the console and doesn't populate the target specific options.

**Solution**: While not the most elegant solution, I added a check for that specific case and modifies it to the proper reference.

I also noticed that you had this issue with the "command" target and that your version of command.json differs from the one in bberliner's repository slightly to account for that. So I also added a check for what the original command.json file uses (still works with your modified version), so now you should also be able to use an unmodified version of command.json.

If you'd rather handle this in a different way, feel free to deny this PR.

Thanks for making such a great tool! 😊